### PR TITLE
swap dim for axis

### DIFF
--- a/capsulelayers.py
+++ b/capsulelayers.py
@@ -134,7 +134,7 @@ class CapsuleLayer(layers.Layer):
         assert self.routings > 0, 'The routings should be > 0.'
         for i in range(self.routings):
             # c.shape=[batch_size, num_capsule, input_num_capsule]
-            c = tf.nn.softmax(b, dim=1)
+            c = tf.nn.softmax(b, axis=1)
 
             # c.shape =  [batch_size, num_capsule, input_num_capsule]
             # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]


### PR DESCRIPTION
When training using out-of-box defaults, TensorFlow throws a deprecation warning in `tf.nn.softmax`. This corrects the model to use the current terminology.