### PR TITLE
Added get_config functions for saving model.

### DIFF
--- a/capsulelayers.py
+++ b/capsulelayers.py
@@ -25,6 +25,10 @@ class Length(layers.Layer):
     def compute_output_shape(self, input_shape):
         return input_shape[:-1]
 
+    def get_config(self):
+        config = super(Length, self).get_config()
+        return config
+
 
 class Mask(layers.Layer):
     """
@@ -62,6 +66,10 @@ class Mask(layers.Layer):
             return tuple([None, input_shape[0][1] * input_shape[0][2]])
         else:  # no true label provided
             return tuple([None, input_shape[1] * input_shape[2]])
+
+    def get_config(self):
+        config = super(Mask, self).get_config()
+        return config
 
 
 def squash(vectors, axis=-1):
@@ -156,6 +164,15 @@ class CapsuleLayer(layers.Layer):
 
     def compute_output_shape(self, input_shape):
         return tuple([None, self.num_capsule, self.dim_capsule])
+
+    def get_config(self):
+        config = {
+            'num_capsule': self.num_capsule,
+            'dim_capsule': self.dim_capsule,
+            'routings': self.routings
+        }
+        base_config = super(CapsuleLayer, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
 
 def PrimaryCap(inputs, dim_capsule, n_channels, kernel_size, strides, padding):


### PR DESCRIPTION
I've been training a CapsNet model on a remote machine with significantly more horsepower than my laptop. Once the model (an .h5 file) is trained, it is then transferred back to my laptop for prediction tasks.

In doing this, I discovered a strange error. While I was able to save the model without error, attempting to load in the model would throw a TypeError when calling an `__init__` function (approximately) six layers deep in the Keras call stack. After digging around in the Keras source code, I found `model.save(filename)` would call a function named `get_config()` on every layer in the network. 

For example, here's the `get_config()` function of Keras' Convolutional layer: 

https://github.com/keras-team/keras/blob/master/keras/layers/convolutional.py#L214

It turns out that Keras maintains a `config` data structure (a dictionary) for each layer of the network. What's stored in `config` is essential to recreating the layer from a saved state. Without saving the values the layer was created with, there's no other way for Keras to know how to correctly load in a layer (at least to my knowledge).

I've added `get_config()` functions for all three custom layers. That being said, since CapuleLayer is the only one with initialization parameters, it seems to be the only one requiring `get_config()`. However, seeing as all other default Keras layers have the `get_config()` function defined, it seems like good practice to include the function in all layers for future maintainability.

As an aside, I haven't found any other reference to this issue anywhere else. It's surprising that the official Keras webpage for [adding a custom layer](https://keras.io/layers/writing-your-own-keras-layers/) doesn't have `get_config()` detailed, as this would affect any custom layers.