### PR TITLE
modified the plot_log function to have a consistent behaviour. data c…

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,39 +2,25 @@ import numpy as np
 from matplotlib import pyplot as plt
 import csv
 import math
+import pandas
 
 def plot_log(filename, show=True):
-    # load data
-    keys = []
-    values = []
-    with open(filename, 'r') as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            if keys == []:
-                for key, value in row.items():
-                    keys.append(key)
-                    values.append(float(value))
-                continue
 
-            for _, value in row.items():
-                values.append(float(value))
-
-        values = np.reshape(values, newshape=(-1, len(keys)))
-        values[:,0] += 1
+    data = pandas.read_csv(filename)
 
     fig = plt.figure(figsize=(4,6))
     fig.subplots_adjust(top=0.95, bottom=0.05, right=0.95)
     fig.add_subplot(211)
-    for i, key in enumerate(keys):
+    for key in data.keys():
         if key.find('loss') >= 0 and not key.find('val') >= 0:  # training loss
-            plt.plot(values[:, 0], values[:, i], label=key)
+            plt.plot(data['epoch'].values, data[key].values, label=key)
     plt.legend()
     plt.title('Training loss')
 
     fig.add_subplot(212)
-    for i, key in enumerate(keys):
+    for key in data.keys():
         if key.find('acc') >= 0:  # acc
-            plt.plot(values[:, 0], values[:, i], label=key)
+            plt.plot(data['epoch'].values, data[key].values, label=key)
     plt.legend()
     plt.title('Training and validation accuracy')
 


### PR DESCRIPTION
…olumns are now accessed by the column names; this does not assume the first column is epoch as before.

`plt.plot(values[:, 0], values[:, i], label=key)`

The line above assumes the epoch is at index 0 but that is not always the case since dictionary keys are ordered arbitrarily. This leads to weird plots like:
![weird_training_profile](https://user-images.githubusercontent.com/7465068/44615624-876de400-a80c-11e8-93fa-6f4a5dc7daf3.png)

This pull request calls each column by the header name and should give a consistent behavior.